### PR TITLE
update: 이미지/해시태그 갯수 제한

### DIFF
--- a/apps/diaries/serializers.py
+++ b/apps/diaries/serializers.py
@@ -125,8 +125,8 @@ class AiDiaryWriteSerializer(serializers.ModelSerializer):
 
         # Images 검증
         images = data.get('images', [])
-        if len(images) > 3:
-            raise serializers.ValidationError("You can only upload up to 3 images.")
+        if len(images) > 1:
+            raise serializers.ValidationError("You can only upload up to 1 images.")
 
         return data
 

--- a/apps/diaries/serializers.py
+++ b/apps/diaries/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from .models import Mood, Hashtag, Diary, DiaryImage
 from django.db import transaction
-from django.shortcuts import get_object_or_404
 
 
 class DiaryImageReadSerializer(serializers.ModelSerializer):
@@ -43,9 +42,9 @@ class DiaryWriteSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         images = validated_data.pop('images', None)
         moods = validated_data.pop('moods', None)  # 클라이언트가 보낸 Mood 리스트
+        mood_id = Mood.objects.get(name=moods)
         hashtags_data = validated_data.pop('hashtags', None)  # 클라이언트가 보낸 hashtag 리스트
         request = self.context.get('request')
-        mood_id = Mood.objects.get(name=moods)
         diary = Diary.objects.create(user=request.user, moods=mood_id,  **validated_data)
 
         hashtag_list = hashtags_data.split(',')

--- a/apps/diaries/serializers.py
+++ b/apps/diaries/serializers.py
@@ -58,7 +58,6 @@ class DiaryWriteSerializer(serializers.ModelSerializer):
         if images:
             for image in images:
                 DiaryImage.objects.create(diary=diary, image=image)
-                pass
 
         return diary
 

--- a/apps/diaries/serializers.py
+++ b/apps/diaries/serializers.py
@@ -56,8 +56,8 @@ class DiaryWriteSerializer(serializers.ModelSerializer):
         return diary
 
     def update(self, instance, validated_data):
-        images = validated_data.pop('images', None)
-        moods = validated_data.pop('moods', None)
+        images = validated_data.pop('images', instance.images)
+        moods = validated_data.pop('moods', instance.moods)
         mood_id = Mood.objects.get(name=moods)
         instance.ymd = validated_data.get('ymd', instance.ymd)
         instance.title = validated_data.get('title', instance.title)
@@ -123,8 +123,8 @@ class AiDiaryWriteSerializer(serializers.ModelSerializer):
         return diary
 
     def update(self, instance, validated_data):
-        images = validated_data.pop('images', None)
-        moods = validated_data.pop('moods', None)
+        images = validated_data.pop('images', instance.images)
+        moods = validated_data.pop('moods', instance.moods)
         mood_id = Mood.objects.get(name=moods)
         hashtags_data = validated_data.pop('hashtags', None)
         instance.ymd = validated_data.get('ymd', instance.ymd)


### PR DESCRIPTION
직접 작성: 이미지 3개
AI작성: 이미지1개, 키워드 3개

와이어프레임에 맞춰 직접 작성일 때는 해시태그(키워드) 안 받는걸로 수정

serializer update쪽 잔오류 수정